### PR TITLE
Adjust releases repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ In addition to that you should already have nuget token set using `nuget setApiK
 ## Usage
 
 ```
-# This bin has to be ran from ckeditor-releases directory.
-cd ckeditor-releases
+# This bin has to be ran from `ckeditor4-releases` directory.
+cd ckeditor4-releases
 ckeditor4-nuget-release <version> --push
 ```
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -21,8 +21,8 @@ if ( !buildVersion || process.argv.includes( '--help' ) ) {
 	process.exit( 0 );
 }
 
-if ( path.basename( RELEASE_PATH ) != 'ckeditor-releases' ) {
-	console.log( 'This script must be called from ckeditor-releases directory.' );
+if ( path.basename( RELEASE_PATH ) != 'ckeditor4-releases' ) {
+	console.log( 'This script must be called from ckeditor4-releases directory.' );
 	process.exit( 0 );
 }
 
@@ -40,7 +40,7 @@ function bundlePreset( presetName, version, buildDir ) {
 
 			cmd += ` -properties preset=-${presetName}`
 
-			// Make sure sources are picked from ckeditor-releases dir and the build is
+			// Make sure sources are picked from ckeditor4-releases dir and the build is
 			// saved in a os tmp dir.
 			cmd += ' -BasePath ' + RELEASE_PATH + ' -OutputDirectory ' + buildDir;
 

--- a/ckeditor.nuspec
+++ b/ckeditor.nuspec
@@ -5,12 +5,12 @@
     <version>$version$</version>
     <authors>CKSource (http://cksource.com/)</authors>
     <owners>ckeditor</owners>
-    <licenseUrl>https://github.com/ckeditor/ckeditor-releases/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>https://github.com/ckeditor/ckeditor-releases</projectUrl>
+    <licenseUrl>https://github.com/ckeditor/ckeditor4-releases/blob/master/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/ckeditor/ckeditor4-releases</projectUrl>
     <iconUrl>https://c.cksource.com/a/1/img/nuget/ckeditor-4.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>JavaScript WYSIWYG web text editor.</description>
-    <releaseNotes>See https://github.com/ckeditor/ckeditor-releases/blob/$version$/CHANGES.md for a complete list of changes.</releaseNotes>
+    <releaseNotes>See https://github.com/ckeditor/ckeditor4-releases/blob/$version$/CHANGES.md for a complete list of changes.</releaseNotes>
     <copyright>Copyright 2003-2019</copyright>
     <tags>ckeditor editor wysiwyg html richtext text javascript</tags>
     <dependencies />

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ckeditor/ckeditor-nuget.git"
+    "url": "git+https://github.com/ckeditor/ckeditor4-nuget-release.git"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "bugs": {
-    "url": "https://github.com/ckeditor/ckeditor-nuget/issues"
+    "url": "https://github.com/ckeditor/ckeditor4-nuget-release/issues"
   },
-  "homepage": "https://github.com/ckeditor/ckeditor-nuget#readme",
+  "homepage": "https://github.com/ckeditor/ckeditor4-nuget-release#readme",
   "dependencies": {
     "child-process-promise": "^2.2.1",
     "command-exists": "^1.2.2",


### PR DESCRIPTION
Since we have changed \`ckeditor-release\` to \`ckeditor4-release\` it will be good to have script up to date so it works with new folder names.