### PR TITLE
Add README support

### DIFF
--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -35,7 +35,7 @@ In order to activate CKEditor 4 LTS, add `licenseKey` configure the editor with 
 </script>
 ```
 
-The NPM package is tagged as 4.23.* without the `-lts` suffix, to keep it consistent with NPM versioning guidelines. Note that the version 4.23.0 and above are the LTS versions of the editor.
+The CKEditor 4 Nuget packages are tagged as 4.23.* without the `-lts` suffix, to keep it consistent with semantic versioning guidelines. Note that the version 4.23.0 and above are the LTS versions of the editor.
 
 ### Getting CKEditor 4 (Open Source)
 
@@ -113,7 +113,7 @@ Since the introduction of the LTS version of CKEditor (`4.23.0-lts`) in July 202
 
 ## Presets
 
-The CKEditor 4 npm package comes in the `standard-all` preset, so it includes all official CKEditor plugins, with those from the [standard package](https://sdk.ckeditor.com/samples/standardpreset.html) active by default.
+The CKEditor 4 Nuget packages come in [`basic`](https://www.nuget.org/packages/ckeditor-basic), [`full`](https://www.nuget.org/packages/ckeditor-full), [`standard`](https://www.nuget.org/packages/ckeditor-standard) and [`standard-all`](https://www.nuget.org/packages/ckeditor-standard-all) presets, so they differ on which of official CKEditor plugins are included in each other. You can check differences between presets in the [official documentation](https://ckeditor.com/cke4/presets-all).
 
 ## Further Resources
 

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -23,19 +23,7 @@ After June 30, 2023 the `master` version of the [LICENSE.md](https://github.com/
 
 All future versions of CKEditor 4 (4.23.0-lts and above) are released as CKEditor 4 LTS distributions and require a license key.
 
-If you acquired the [Extended Support Model](https://ckeditor.com/ckeditor-4-support/) for CKEditor 4 LTS, please read [the CKEditor 4 LTS key activation guide.](https://ckeditor.com/docs/ckeditor4/latest/support/licensing/license-key-and-activation.html)
-
-In order to activate CKEditor 4 LTS, add `licenseKey` configure the editor with a valid license key:
-
-```html
-<script>
-    CKEDITOR.replace( 'editor', {
-        licenseKey: 'your license key'
-    } );
-</script>
-```
-
-The CKEditor 4 Nuget packages are tagged as 4.23.* without the `-lts` suffix, to keep it consistent with semantic versioning guidelines. Note that the version 4.23.0 and above are the LTS versions of the editor.
+The CKEditor 4 Nuget packages are tagged as 4.23.* without the `-lts` suffix, to keep it consistent with NPM versioning guidelines. Note that the version 4.23.0 and above are the LTS versions of the editor.
 
 ### Getting CKEditor 4 (Open Source)
 
@@ -98,7 +86,17 @@ You can also load CKEditor 4 using [CDN](https://cdn.ckeditor.com/#ckeditor4).
 
 #### CKEditor 4 LTS
 
-Since the introduction of the LTS version of CKEditor (`4.23.0-lts`) in July 2023, all future versions of CKEditor 4 will contain `-lts` in their version number.
+If you acquired the [Extended Support Model](https://ckeditor.com/ckeditor-4-support/) for CKEditor 4 LTS, please read [the CKEditor 4 LTS key activation guide.](https://ckeditor.com/docs/ckeditor4/latest/support/licensing/license-key-and-activation.html)
+
+In order to activate CKEditor 4 LTS, add `licenseKey` configure the editor with a valid license key:
+
+```html
+<script>
+    CKEDITOR.replace( 'editor', {
+        licenseKey: 'your license key'
+    } );
+</script>
+```
 
 ## Features
 

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/ckeditor4.svg)](https://www.npmjs.com/package/ckeditor4)
 [![GitHub tag](https://img.shields.io/github/tag/ckeditor/ckeditor4.svg)](https://github.com/ckeditor/ckeditor4-releases)
-[![Build Status](https://app.travis-ci.com/ckeditor/ckeditor4.svg?branch=master)](https://app.travis-ci.com/ckeditor/ckeditor4)
+[![Build Status](https://api.travis-ci.com/ckeditor/ckeditor4.svg?branch=master)](https://app.travis-ci.com/ckeditor/ckeditor4)
 
 [![Join newsletter](https://img.shields.io/badge/join-newsletter-00cc99.svg)](http://eepurl.com/c3zRPr)
 [![Follow Twitter](https://img.shields.io/badge/follow-twitter-00cc99.svg)](https://twitter.com/ckeditor)
@@ -70,7 +70,7 @@ A highly configurable WYSIWYG HTML editor with hundreds of features, from creati
 
 It supports a broad range of browsers, including legacy ones.
 
-![CKEditor 4 screenshot](https://c.cksource.com/a/1/img/npm/ckeditor4.png)
+![CKEditor 4 screenshot](https://raw.githubusercontent.com/ckeditor/ckeditor4-releases/master/.npm/assets/ckeditor4.png)
 
 ## Getting started
 

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -1,7 +1,7 @@
 # CKEditor 4 LTS - Smart WYSIWYG HTML editor [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20CKEditor%204%20on%20GitHub&url=https%3A%2F%2Fgithub.com%2Fckeditor%2Fckeditor4)
 
 [![npm version](https://badge.fury.io/js/ckeditor4.svg)](https://www.npmjs.com/package/ckeditor4)
-[![GitHub tag](https://img.shields.io/github/tag/ckeditor/ckeditor4.svg)](https://github.com/ckeditor/ckeditor4-releases)
+[![GitHub tag](https://img.shields.io/github/v/tag/ckeditor/ckeditor4.svg)](https://github.com/ckeditor/ckeditor4-releases)
 [![Build Status](https://api.travis-ci.com/ckeditor/ckeditor4.svg?branch=master)](https://app.travis-ci.com/ckeditor/ckeditor4)
 
 [![Join newsletter](https://img.shields.io/badge/join-newsletter-00cc99.svg)](http://eepurl.com/c3zRPr)

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -1,0 +1,152 @@
+# CKEditor 4 LTS - Smart WYSIWYG HTML editor [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20CKEditor%204%20on%20GitHub&url=https%3A%2F%2Fgithub.com%2Fckeditor%2Fckeditor4)
+
+[![npm version](https://badge.fury.io/js/ckeditor4.svg)](https://www.npmjs.com/package/ckeditor4)
+[![GitHub tag](https://img.shields.io/github/tag/ckeditor/ckeditor4.svg)](https://github.com/ckeditor/ckeditor4-releases)
+[![Build Status](https://app.travis-ci.com/ckeditor/ckeditor4.svg?branch=master)](https://app.travis-ci.com/ckeditor/ckeditor4)
+
+[![Join newsletter](https://img.shields.io/badge/join-newsletter-00cc99.svg)](http://eepurl.com/c3zRPr)
+[![Follow Twitter](https://img.shields.io/badge/follow-twitter-00cc99.svg)](https://twitter.com/ckeditor)
+
+## ⚠️ CKEditor 4: End of Life and Extended Support Model until Dec 2026
+
+CKEditor 4 was launched in 2012 and reached its End of Life (EOL) on June 30, 2023.
+
+A special edition, **[CKEditor 4 LTS](https://ckeditor.com/ckeditor-4-support/)** ("Long Term Support"), is available under commercial terms (["Extended Support Model"](https://ckeditor.com/ckeditor-4-support/)) for anyone looking to **extend the coverage of security updates and critical bug fixes**.
+
+With CKEditor 4 LTS, security updates and critical bug fixes are guaranteed until December 2026.
+
+## About this package
+
+### CKEditor 4 LTS
+
+After June 30, 2023 the `master` version of the [LICENSE.md](https://github.com/ckeditor/ckeditor4/blob/master/LICENSE.md) file changed to reflect the license of CKEditor 4 LTS available under the Extended Support Model.
+
+All future versions of CKEditor 4 (4.23.0-lts and above) are released as CKEditor 4 LTS distributions and require a license key.
+
+If you acquired the [Extended Support Model](https://ckeditor.com/ckeditor-4-support/) for CKEditor 4 LTS, please read [the CKEditor 4 LTS key activation guide.](https://ckeditor.com/docs/ckeditor4/latest/support/licensing/license-key-and-activation.html)
+
+In order to activate CKEditor 4 LTS, add `licenseKey` configure the editor with a valid license key:
+
+```html
+<script>
+    CKEDITOR.replace( 'editor', {
+        licenseKey: 'your license key'
+    } );
+</script>
+```
+
+The NPM package is tagged as 4.23.* without the `-lts` suffix, to keep it consistent with NPM versioning guidelines. Note that the version 4.23.0 and above are the LTS versions of the editor.
+
+### Getting CKEditor 4 (Open Source)
+
+You may continue using CKEditor 4.22.* and below under the open source license terms. Please note, however, that the open source version no longer comes with any security updates, so your application will be at risk.
+
+In order to install the open source version of CKEditor 4, use ****versions 4.22.1 and below****. CKEditor 4.22.1 was the last version of CKEditor 4 available under the open source license terms.
+
+## Summary of options after the CKEditor 4 End of Life
+
+### Upgrading to CKEditor 5
+
+CKEditor 5 is a great new editor with [lots of exciting features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html).
+
+Before upgrading, please be aware of the following changes:
+
+- CKEditor 5 is a completely new editor. **Upgrading is not as simple as replacing the folder with "ckeditor"** - read more in the [Migration from CKEditor 4](https://ckeditor.com/docs/ckeditor5/latest/updating/ckeditor4/migration-from-ckeditor-4.html) guide.
+- CKEditor 5 is available only under the GPL copyleft license (or under a commercial license).
+- Open source projects with a GPL-incompatible license may apply for a license under the [Free for Open Source](https://ckeditor.com/wysiwyg-editor-open-source/) program.
+
+### Using an outdated, unsupported version
+
+You may continue using CKEditor 4.22.* (or below). The license terms of the older CKEditor 4 versions have not changed. However, please note that by using software that is no longer maintained, you are introducing a **security risk to your application**.
+
+### Signing an "Extended Support Model" contract
+
+If you are not ready to replace CKEditor 4 in your application yet, you may continue using CKEditor 4 until December 2026.
+CKEditor 4 LTS, available under the "[Extended Support Model](https://ckeditor.com/ckeditor-4-support/)", will ship all important security updates and critical bug fixes, providing an interrupted editing experience for your end users. Please note that this version of CKEditor 4 is available only under a special agreement and requires a license key.
+
+## About CKEditor 4
+
+A highly configurable WYSIWYG HTML editor with hundreds of features, from creating rich text content with captioned images, videos, tables, media embeds, emoji, or mentions to pasting from Word and Google Docs and drag&drop image upload.
+
+It supports a broad range of browsers, including legacy ones.
+
+![CKEditor 4 screenshot](https://c.cksource.com/a/1/img/npm/ckeditor4.png)
+
+## Getting started
+
+### Using [npm package](https://www.npmjs.com/package/ckeditor4)
+
+```bash
+npm install --save ckeditor4
+```
+
+Use it on your website:
+
+```html
+<div id="editor">
+    <p>This is the editor content.</p>
+</div>
+<script src="./node_modules/ckeditor4/ckeditor.js"></script>
+<script>
+    CKEDITOR.replace( 'editor' );
+</script>
+```
+
+You can also load CKEditor 4 using [CDN](https://cdn.ckeditor.com/#ckeditor4).
+
+#### CKEditor 4 LTS
+
+Since the introduction of the LTS version of CKEditor (`4.23.0-lts`) in July 2023, all future versions of CKEditor 4 will contain `-lts` in their version number.
+
+## Features
+
+* Over 500 plugins in the [Add-ons Repository](https://ckeditor.com/cke4/addons).
+* Pasting from Microsoft Word, Excel, and Google Docs.
+* Drag&drop image uploads.
+* Media embeds to insert videos, tweets, maps, or slideshows.
+* Powerful clipboard integration.
+* Content quality control with Advanced Content Filter.
+* Extensible widget system.
+* Custom table selection.
+* Accessibility conforming to WCAG and Section 508.
+* Over 70 localizations available with full RTL support.
+
+## Presets
+
+The CKEditor 4 npm package comes in the `standard-all` preset, so it includes all official CKEditor plugins, with those from the [standard package](https://sdk.ckeditor.com/samples/standardpreset.html) active by default.
+
+## Further Resources
+
+* [CKEditor 4 demo](https://ckeditor.com/ckeditor-4/)
+* [Documentation](https://ckeditor.com/docs/ckeditor4/latest/)
+* [API documentation](https://ckeditor.com/docs/ckeditor4/latest/api/index.html)
+* [Configuration reference](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html)
+* [CKEditor SDK with more samples](https://sdk.ckeditor.com/)
+
+If you are looking for CKEditor 5, here's a link to the relevant npm package: <https://www.npmjs.com/package/ckeditor5>
+
+## Browser support
+
+| [![IE / Edge](https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png)](http://godban.github.io/browsers-support-badges/) IE / Edge | [![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png)](http://godban.github.io/browsers-support-badges/) Firefox | [![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png)](http://godban.github.io/browsers-support-badges/) Chrome | [![Chrome (Android)](https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png)](http://godban.github.io/browsers-support-badges/) Chrome (Android) | [![Safari](https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png)](http://godban.github.io/browsers-support-badges/) Safari | [![iOS Safari](https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png)](http://godban.github.io/browsers-support-badges/) iOS Safari | [![Opera](https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png)](http://godban.github.io/browsers-support-badges/) Opera |
+| --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+| IE8, IE9, IE10, IE11, Edge | latest version | latest version | latest version | latest version | latest version | latest version |
+
+Find out more in the [Browser Compatibility guide](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_browsers.html#officially-supported-browsers).
+
+## License
+
+Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+
+For licensing, see LICENSE.md or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license)
+
+### CKEditor 4.22.* and below
+
+CKEditor 4 until version 4.22.* was licensed under the terms of any of the following licenses of your choice:
+
+ - GNU General Public License Version 2 or later.
+ - GNU Lesser General Public License Version 2.1 or later.
+ - Mozilla Public License Version 1.1 or later.
+
+### CKEditor 4.23.0-lts and above
+
+CKEditor 4 LTS (starting from version 4.23.0-lts) is available under a commercial license only.

--- a/.nuget/README.md
+++ b/.nuget/README.md
@@ -74,11 +74,13 @@ It supports a broad range of browsers, including legacy ones.
 
 ## Getting started
 
-### Using [npm package](https://www.npmjs.com/package/ckeditor4)
+### Using [Nuget package](https://www.nuget.org/packages/ckeditor-standard)
 
 ```bash
-npm install --save ckeditor4
+nuget install ckeditor4-standard
 ```
+
+Instead of the standard preset, you can use any of the [supported presets](#presets).
 
 Use it on your website:
 
@@ -86,7 +88,7 @@ Use it on your website:
 <div id="editor">
     <p>This is the editor content.</p>
 </div>
-<script src="./node_modules/ckeditor4/ckeditor.js"></script>
+<script src="./ckeditor-standard.<version>/content/Scripts/ckeditor/ckeditor.js"></script>
 <script>
     CKEDITOR.replace( 'editor' );
 </script>

--- a/bin/index.js
+++ b/bin/index.js
@@ -27,7 +27,7 @@ if ( path.basename( RELEASE_PATH ) != 'ckeditor4-releases' ) {
 }
 
 function bundlePreset( presetName, version, buildDir ) {
-	var releaseTag = presetName === STANDARD_ALL ? version : `${presetName}/${version}`;
+	const releaseTag = presetName === STANDARD_ALL ? `${ version }-lts` : `${ presetName }/${ version }-lts`;
 
 	console.log( `---\nBundling ${presetName} NuGet package...` );
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -43,7 +43,7 @@ async function bundlePreset( presetName, version, buildDir ) {
 		} );
 
 		// Copy the cached readme back to the project dir.
-		await copyReadme( buildDir, presetDir );
+		await copyReadme( presetDir );
 
 		// Use nuget bin to bundle package.
 		let nuspecPath = path.join( path.dirname( __filename ), '..', 'ckeditor.nuspec' ),
@@ -89,25 +89,11 @@ run the script once again.` );
 		} );
 }
 
-async function cacheReadme( version, tempDirectory ) {
-	const releaseTag = `${ version }-lts`;
+async function copyReadme( presetDir ) {
+	const readmeSourcePath = path.resolve( __dirname, '..', '.nuget', 'README.md' );
+	const readmeDistPath = path.resolve( presetDir, 'README.md' );
 
-	await exec( `git checkout ${ releaseTag }` );
-
-	const readmeSrcDir = path.resolve( RELEASE_PATH, '.npm' );
-	const readmeCacheDir = path.resolve( tempDirectory, 'readme' );
-
-	await cp( readmeSrcDir, readmeCacheDir, {
-		recursive: true
-	} );
-}
-
-async function copyReadme( tempDirectory, presetDir ) {
-	const readmeCacheDir = path.resolve( tempDirectory, 'readme' );
-
-	await cp( readmeCacheDir, presetDir, {
-		recursive: true
-	} );
+	await cp( readmeSourcePath, readmeDistPath );
 }
 
 async function publishNugets() {
@@ -117,8 +103,6 @@ async function publishNugets() {
 		await checkNugetBinary();
 
 		let buildDir = osTmpDir().name;
-
-		await cacheReadme( buildVersion, buildDir );
 
 		for ( let presetName of presets ) {
 			await bundlePreset( presetName, buildVersion, buildDir );

--- a/ckeditor.nuspec
+++ b/ckeditor.nuspec
@@ -17,6 +17,6 @@
     <dependencies />
   </metadata>
    <files>
-        <file src="**\*.*" target="content\Scripts\ckeditor" exclude="samples\**\*.*;bower.json;build-config.js;composer.json;.git\**\*.*" />
+        <file src="**\*.*" target="content\Scripts\ckeditor" exclude="samples\**\*.*;bower.json;build-config.js;composer.json;.git\**\*.*;.npm\**\*.*" />
 	</files>
 </package>

--- a/ckeditor.nuspec
+++ b/ckeditor.nuspec
@@ -10,6 +10,7 @@
     <iconUrl>https://c.cksource.com/a/1/img/nuget/ckeditor-4.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>JavaScript WYSIWYG web text editor.</description>
+    <readme>content\Scripts\ckeditor\README.md</readme>
     <releaseNotes>See https://github.com/ckeditor/ckeditor4-releases/blob/$version$/CHANGES.md for a complete list of changes.</releaseNotes>
     <copyright>Copyright 2003-2019</copyright>
     <tags>ckeditor editor wysiwyg html richtext text javascript</tags>

--- a/ckeditor.nuspec
+++ b/ckeditor.nuspec
@@ -12,7 +12,7 @@
     <description>JavaScript WYSIWYG web text editor.</description>
     <readme>content\Scripts\ckeditor\README.md</readme>
     <releaseNotes>See https://github.com/ckeditor/ckeditor4-releases/blob/$version$/CHANGES.md for a complete list of changes.</releaseNotes>
-    <copyright>Copyright 2003-2019</copyright>
+    <copyright>Copyright 2003-2023</copyright>
     <tags>ckeditor editor wysiwyg html richtext text javascript</tags>
     <dependencies />
   </metadata>


### PR DESCRIPTION
I've added the support for `README.md` files.

As the readme is inside the `.npm` directory which is present only in the `standard-all` preset, the whole process is convoluted:

1.  Check out the `<version>-lts` branch.
2.  Copy the `.npm` directory to the temp dir.
3.  Check out the branch of the desired preset.
4.  Copy the contents of the branch to a temp directory (it's needed to keep a clean git state).
5.  Copy the cached readme files to the preset temp directory.
6.  Build a nuget package from that preset temp directory.

The 4. step is necessary as without a clean git state we won't be able to checkout another preset and build the package for it. And the state becomes "dirty" due to copying the readme file which git sees as modifying the `README.md` file. There's an alternative way of keeping the git state clean: run the `git checkout -- .` command after building a package.

I've checked the readme using a [way recommended in docs](https://learn.microsoft.com/en-gb/nuget/nuget-org/package-readme-on-nuget-org#preview-your-readme). Unfortunately, I've noticed that README does not fully work as [Nuget skips images that are not from trusted domains](https://learn.microsoft.com/en-gb/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges):

![Browser icons from the raw.githubusercontent.com domain are skipped.](https://github.com/ckeditor/ckeditor4-nuget-release/assets/1078728/7665d42a-8c9d-4f94-8000-f3368d34947c)

![A screenshot of the editor, which is embedded in the package, is also skipped.](https://github.com/ckeditor/ckeditor4-nuget-release/assets/1078728/137a5860-9191-4a69-9be7-9a2d72ec6fd1)

Probably we will need to create a dedicated README for Nuget.